### PR TITLE
Prysm private testnet docker configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.prysm
 storybook-static
 node_modules/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.prysm
 storybook-static
 node_modules/
 dist/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,14 @@ services:
   prysm-beacon-chain:
     image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
     container_name: "cg_prysm_beacon_chain"
-    command: --datadir=/data --custom-genesis-delay=0 --bootstrap-node= --deposit-contract 0x4689a3C63CE249355C8a573B5974db21D2d1b8Ef --interop-num-validators 8 --interop-eth1data-votes
+    command: --datadir=/data --custom-genesis-delay=0 --bootstrap-node= --deposit-contract 0x4689a3C63CE249355C8a573B5974db21D2d1b8Ef --interop-num-validators 64 --interop-eth1data-votes
     ports:
      - "4000:4000"
      - "13000:13000"
   prysm-validator:
     image: gcr.io/prysmaticlabs/prysm/validator:latest
     container_name: "cg_prysm_validator"
-    command: --keymanager=interop --keymanageropts='{"keys":8}' --beacon-rpc-provider prysm-beacon-chain:4000
+    command: --keymanager=interop --keymanageropts='{"keys":64}' --beacon-rpc-provider prysm-beacon-chain:4000
     restart: on-failure
     depends_on:
       - prysm-beacon-chain

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,9 @@ version: "3"
 services:
   prysm-beacon-chain:
     image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
+    command: --datadir=/data --custom-genesis-delay=0 --bootstrap-node= --deposit-contract 0x4689a3C63CE249355C8a573B5974db21D2d1b8Ef --interop-num-validators 8 --interop-eth1data-votes
     ports:
      - "4000:4000"
      - "13000:13000"
     volumes:
-     - "./prysm:/data"
+     - ".prysm:/data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,15 @@ version: "3"
 services:
   prysm-beacon-chain:
     image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
+    container_name: "cg_prysm_beacon_chain"
     command: --datadir=/data --custom-genesis-delay=0 --bootstrap-node= --deposit-contract 0x4689a3C63CE249355C8a573B5974db21D2d1b8Ef --interop-num-validators 8 --interop-eth1data-votes
     ports:
      - "4000:4000"
      - "13000:13000"
-    volumes:
-     - ".prysm:/data"
+  prysm-validator:
+    image: gcr.io/prysmaticlabs/prysm/validator:latest
+    container_name: "cg_prysm_validator"
+    command: --keymanager=interop --keymanageropts='{"keys":8}' --beacon-rpc-provider prysm-beacon-chain:4000
+    restart: on-failure
+    depends_on:
+      - prysm-beacon-chain

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  prysm-beacon-chain:
+    image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
+    ports:
+     - "4000:4000"
+     - "13000:13000"
+    volumes:
+     - "./prysm:/data"


### PR DESCRIPTION
Resolves #140 

Uses 64 validators as it turns out that is the minimum for Prysm.

Note: Connects to Goerli deposit contract but mocking ETH1 data